### PR TITLE
Improve example of executed unreachable code

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,8 +483,9 @@ xxx = 1
 def foo():
   if False:
     global xxx
-  return xxx
-print(foo())  # Prints 1
+  xxx = 42
+foo()
+print(xxx)  # Prints 42
 ```
 
 ## Relative imports are unusable


### PR DESCRIPTION
The old example did not illustrate the problem very well, as it works even without the unreachable branch.

```py
x = 1
def a():
    return x
print(a())  # Prints 1
```

This change fixes that by assigning to the global variable, which is not possible without the `global` keyword, thus better illustrating the execution of unreachable code.